### PR TITLE
Minor typo in indi_pylibcamera.py

### DIFF
--- a/src/indi_pylibcamera/indi_pylibcamera.py
+++ b/src/indi_pylibcamera/indi_pylibcamera.py
@@ -99,7 +99,7 @@ class ConnectionVector(ISwitchVector):
             device=self.parent.device, timestamp=self.parent.timestamp, name="CONNECTION",
             elements=[
                 ISwitch(name="CONNECT", label="Connect", value=ISwitchState.OFF),
-                ISwitch(name="DISCONNECT", label="Disonnect", value=ISwitchState.ON),
+                ISwitch(name="DISCONNECT", label="Disconnect", value=ISwitchState.ON),
             ],
             label="Connection", group="Main Control",
             rule=ISwitchRule.ONEOFMANY, is_savable=False,


### PR DESCRIPTION
I noticed the word "Disconnect" was misspelled (missing a "c") in the enumeration labels of `ConnectionVector`. This PR adds a single character to fix it. :)